### PR TITLE
Fix the support for Rails 6.1

### DIFF
--- a/lib/jsonapi/resource_controller_metal.rb
+++ b/lib/jsonapi/resource_controller_metal.rb
@@ -5,10 +5,10 @@ module JSONAPI
       ActionController::Rendering,
       ActionController::Renderers::All,
       ActionController::StrongParameters,
-      ActionController::ForceSSL,
+      Gem::Requirement.new('< 6.1').satisfied_by?(ActionPack.gem_version) ? ActionController::ForceSSL : nil,
       ActionController::Instrumentation,
       JSONAPI::ActsAsResourceController
-    ].freeze
+    ].compact.freeze
 
     MODULES.each do |mod|
       include mod


### PR DESCRIPTION
The `ActionController::ForceSSL` was removed in Rails 6.1: https://guides.rubyonrails.org/v6.1/upgrading_ruby_on_rails.html#force-ssl

The main version of jsonapi_resources fixed the compatibility in this commit: https://github.com/cerebris/jsonapi-resources/pull/1346/commits/7d07f357ea67addf4ad782405a45db3cb6685c20#diff-049e4390dcf1a56da697a2c93822f13732e378b7f11f7a6b71c62642096138adR8